### PR TITLE
Manage sudoers file for passwordless vagrant up/down with NFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Manage sudoers file for passwordless vagrant up/down with NFS
+
 ## [1.1.0] - 2017-02-01
 ### Added
 - Add installation of vagrant plugins for given users

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The version of Vagrant which should be installed.
 
+    vagrant_manage_sudoers: false
+
+If the sudoers file should be managed for passwordless vagrant up/down if using NFS. If true, a `/etc/sudoers.d/vagrant-syncedfolders` will be created and the `#includedir /etc/sudoers.d` directive activated. This is managed only for Ubuntu now. On Ubuntu the user must be in the `sudo` group.
+
     vagrant_plugin_users: []
     
 Add a list of user account names for which vagrant plugins should be installed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 vagrant_version: '1.9.1'
+vagrant_manage_sudoers: false
 
 # Download URL
 vagrant_download_url: 'https://releases.hashicorp.com/vagrant/{{ vagrant_version }}'

--- a/tasks/configure-sudoers.yml
+++ b/tasks/configure-sudoers.yml
@@ -1,0 +1,25 @@
+---
+- name: Configure sudoers directory.
+  file:
+    path: /etc/sudoers.d
+    state: directory
+    group: root
+    owner: root
+    mode: 0755
+
+- name: Configure sudoers directory is scanned.
+  become: yes
+  lineinfile:
+    regexp: '#includedir\s+/etc/sudoers.d'
+    line: '#includedir /etc/sudoers.d'
+    dest: /etc/sudoers
+
+- name: Manage vagrant-syncedfolders sudoers file.
+  template:
+    dest: /etc/sudoers.d/vagrant-syncedfolders
+    src: 'sudoers-{{ ansible_distribution }}.j2'
+    owner: root
+    group: root
+    mode: 440
+    force: yes
+    validate: 'visudo -cf %s'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,8 @@
 ---
+- include: configure-sudoers.yml
+  static: no
+  when: vagrant_manage_sudoers and (ansible_distribution == 'Ubuntu')
+
 - name: Install Vagrant plugins
   become: true
   become_user: "{{ item.0 }}"

--- a/templates/sudoers-Ubuntu.j2
+++ b/templates/sudoers-Ubuntu.j2
@@ -1,0 +1,7 @@
+Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
+Cmnd_Alias VAGRANT_EXPORTS_COPY = /bin/cp /tmp/exports /etc/exports
+Cmnd_Alias VAGRANT_NFSD_CHECK = /etc/init.d/nfs-kernel-server status
+Cmnd_Alias VAGRANT_NFSD_START = /etc/init.d/nfs-kernel-server start
+Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
+Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /bin/sed -r -e * d -ibak /tmp/exports
+%sudo ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY, VAGRANT_EXPORTS_REMOVE, VAGRANT_EXPORTS_COPY

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,9 @@
   remote_user: root
 
   vars:
+    # Test editing of sudoers file
+    vagrant_manage_sudoers: true
+
     # Test a vagrant plugin
     vagrant_plugin_users: ['{{ ansible_user }}']
     vagrant_plugins:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Manages the sudoers file for Ubuntu for passwordless vagrant up/down with NFS synced folders according to https://www.vagrantup.com/docs/synced-folders/nfs.html#root-privilege-requirement

#### Why?

Otherwise you would have to enter your sudo password on vagrant up/down which can be quite annoying.

#### Example Usage

```yaml
vagrant_manage_sudoers: true
```
