### PR TITLE
Fix managed sudoers file for changed occurred in Vagrant 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fix managed sudoers file for changed occurred in Vagrant 1.9.1
+
 ## [1.2.1] - 2017-02-02
 ### Fixed
 - Add missing leading zero on the sudoers file permissions

--- a/tasks/configure-sudoers.yml
+++ b/tasks/configure-sudoers.yml
@@ -14,10 +14,19 @@
     line: '#includedir /etc/sudoers.d'
     dest: /etc/sudoers
 
+- name: Set default sudoers template
+  set_fact:
+    vagrant_sudoers_template: 'sudoers-{{ ansible_distribution }}.j2'
+
+- name: Set sudoers template for Ubuntu and Vagrant version below 1.9.1
+  set_fact:
+    vagrant_sudoers_template: 'sudoers-{{ ansible_distribution }}-lt-1-9-1.j2'
+  when: ansible_distribution == 'Ubuntu' and vagrant_version|version_compare('1.9.1', '<')
+
 - name: Manage vagrant-syncedfolders sudoers file.
   template:
     dest: /etc/sudoers.d/vagrant-syncedfolders
-    src: 'sudoers-{{ ansible_distribution }}.j2'
+    src: '{{ vagrant_sudoers_template }}'
     owner: root
     group: root
     mode: 0440

--- a/templates/sudoers-Ubuntu-lt-1-9-1.j2
+++ b/templates/sudoers-Ubuntu-lt-1-9-1.j2
@@ -1,0 +1,7 @@
+Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
+Cmnd_Alias VAGRANT_EXPORTS_COPY = /bin/cp /tmp/exports /etc/exports
+Cmnd_Alias VAGRANT_NFSD_CHECK = /etc/init.d/nfs-kernel-server status
+Cmnd_Alias VAGRANT_NFSD_START = /etc/init.d/nfs-kernel-server start
+Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
+Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /bin/sed -r -e * d -ibak /tmp/exports
+%sudo ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY, VAGRANT_EXPORTS_REMOVE, VAGRANT_EXPORTS_COPY

--- a/templates/sudoers-Ubuntu.j2
+++ b/templates/sudoers-Ubuntu.j2
@@ -1,7 +1,6 @@
-Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
-Cmnd_Alias VAGRANT_EXPORTS_COPY = /bin/cp /tmp/exports /etc/exports
+Cmnd_Alias VAGRANT_EXPORTS_CHOWN = /bin/chown 0\:0 /tmp/*
+Cmnd_Alias VAGRANT_EXPORTS_MV = /bin/mv -f /tmp/* /etc/exports
 Cmnd_Alias VAGRANT_NFSD_CHECK = /etc/init.d/nfs-kernel-server status
 Cmnd_Alias VAGRANT_NFSD_START = /etc/init.d/nfs-kernel-server start
 Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
-Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /bin/sed -r -e * d -ibak /tmp/exports
-%sudo ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY, VAGRANT_EXPORTS_REMOVE, VAGRANT_EXPORTS_COPY
+%sudo ALL=(root) NOPASSWD: VAGRANT_EXPORTS_CHOWN, VAGRANT_EXPORTS_MV, VAGRANT_NFSD_CHECK, VAGRANT_NFSD_START, VAGRANT_NFSD_APPLY


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #2 
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Uses the sudoers configuration from mitchellh/vagrant#8219 on Ubuntu and vagrant version >= 1.9.1

And added a test matrix entry, which tests the template for versions below 1.9.1

#### Example Usage

```yaml
vagrant_version: '1.9.1'
vagrant_manage_sudoers: true
```
