### PR TITLE
Update default Vagrant version to 1.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Update default Vagrant version to 1.9.4
+
 ## [1.2.3] - 2017-03-10
 ### Fixed
 - Correct old sudoers template to the right version < 1.8.7

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installs [Vagrant](https://www.vagrantup.com/) on Ubuntu or Debian.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    vagrant_version: '1.9.1'
+    vagrant_version: '1.9.4'
 
 The version of Vagrant which should be installed.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-vagrant_version: '1.9.1'
+vagrant_version: '1.9.4'
 vagrant_manage_sudoers: false
 
 # Download URL


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT