### PR TITLE
Keep vagrant plugins updated if configured

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
     || (echo 'Idempotence test: fail' && exit 1)
 
   # Ensure platform.sh CLI is installed and working.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm vagrant || true'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm vagrant --version'
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+## Added
+- Keep vagrant plugins updated if configured
+
 ## [1.2.4] - 2017-05-09
 ### Changed
 - Update default Vagrant version to 1.9.4

--- a/README.md
+++ b/README.md
@@ -26,14 +26,20 @@ Add a list of user account names for which vagrant plugins should be installed.
 
     vagrant_plugins: []
 
-Add a list of vagrant with a `name` and (optional) `version` to be installed for the users above. For example:
+Add a list of vagrant with a `name` and (optional) `version` constraint or specific version to be installed for the users above. For example:
 
-    vagrant_plugins:
-      # Install a specific version of a plugin.
-      - name: vagrant-bindfs
-        version: 1.0.1
-      # Install the latest stable release of a plugin.
-      - name: vagrant-cachier
+```yaml
+vagrant_plugins:
+  # Install a higher version than supplied by the system
+  - name: vagrant-share
+    version: '>=1.1.8'
+  # Install the latest stable release of a plugin.
+  - name: vagrant-cachier
+```
+
+    vagrant_plugins_keep_updated: false
+    
+Set to true if you want to keep the vagrant plugins installed updated. If you set this to true, only plugins without version constraint above are updated. Install with specific version and update is mutually exclusive.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ vagrant_checksum_url: '{{ vagrant_download_url }}/vagrant_{{ vagrant_version }}_
 # Vagrant plugins
 vagrant_plugin_users: []
 vagrant_plugins: []
+vagrant_plugins_keep_updated: false

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -13,3 +13,14 @@
     - "{{ vagrant_plugin_users }}"
     - "{{ vagrant_plugins }}"
   changed_when: false
+
+- name: Ensure Vagrant plugins are updated (if configured)
+  become: true
+  become_user: "{{ item.0 }}"
+  command: vagrant plugin update {{ item.1.name }}
+  when: vagrant_plugins_keep_updated and item.1.version is not defined
+  register: vagrant_plugin_update
+  changed_when: '"Updated" in vagrant_plugin_update.stdout'
+  with_nested:
+    - "{{ vagrant_plugin_users }}"
+    - "{{ vagrant_plugins }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,7 +10,9 @@
     vagrant_plugin_users: ['{{ ansible_user }}']
     vagrant_plugins:
       - name: vagrant-bindfs
-        version: 1.0.1
+      - name: vagrant-share
+        version: '>=1.1.8'
+    vagrant_plugins_keep_updated: true
 
   pre_tasks:
     - name: Update apt cache.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

Keep vagrant plugins updated if configured. By default a vagrant plugin install doesn't update the plugin if already installed.

EDIT: Doesn't update any plugins which have a version constraint defined.